### PR TITLE
Migrating from master and slave jargon

### DIFF
--- a/fetcherW.py
+++ b/fetcherW.py
@@ -41,8 +41,8 @@ consumerSecret = 'DlPdIXIkwgCGZLp0IUjU5418a9txJrp27qKsGovZh9iumcXyYy'
 
 # DB credentials
 config = {
-  'user': 'piemaster',
-  'password': 'piemaster123',
+  'user': 'piemain',
+  'password': 'piemain123',
   'host': 'piedb.chhtgdmxqekc.us-east-1.rds.amazonaws.com',
   'database': 'PieDB',
   'raise_on_warnings': True,


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.